### PR TITLE
Replace ggplot() by new plot and addPlot methods where possible

### DIFF
--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -36,6 +36,7 @@ format:
 
 website:
   title: "mizer course"
+  llms-txt: true
   site-url: "https://mizer.course.sizespectrum.org"
   favicon: images/favicon-16x16.png
   repo-url: https://github.com/gustavdelius/mizerCourse

--- a/understand/predation-growth-and-mortality.qmd
+++ b/understand/predation-growth-and-mortality.qmd
@@ -43,18 +43,11 @@ Let's make a plot to check that this did what we intended:
 plotSpectra(params_starved, power = 2, species = FALSE)
 ```
 
-The plot shows the big drop in the background abundance in our selected size range. This reduced availability of prey in that size range will lead to a drop in the growth rate in the fish that feed in that size range. We can see the slow-down in growth by comparing the growth rates in the original model and the new model. We will use the method that we saw at the end of the previous tutorial in the section "[Two curves in one plot](single-species-spectra.qmd#two-curves-in-one-plot)".
+The plot shows the big drop in the background abundance in our selected size range. This reduced availability of prey in that size range will lead to a drop in the growth rate in the fish that feed in that size range. We can see the slow-down in growth by comparing the growth rates in the original model and the new model using `plot()` and `addPlot()`.
 
 ```{r}
-gf_original <- melt(getEGrowth(params))
-gf_original$Model <- "Original"
-gf_starved <- melt(getEGrowth(params_starved))
-gf_starved$Model <- "Less prey"
-gf <- rbind(gf_original, gf_starved)
-growth_rates_plot <- ggplot(gf, aes(x = w, y = value, linetype = Model)) +
-    geom_line() +
-    scale_x_log10("Weight [g]") +
-    ylab("Growth rate [g/year]")
+growth_rates_plot <- plot(getEGrowth(params))
+growth_rates_plot <- addPlot(growth_rates_plot, getEGrowth(params_starved))
 growth_rates_plot
 ```
 

--- a/understand/predation-growth-and-mortality.qmd
+++ b/understand/predation-growth-and-mortality.qmd
@@ -46,8 +46,8 @@ plotSpectra(params_starved, power = 2, species = FALSE)
 The plot shows the big drop in the background abundance in our selected size range. This reduced availability of prey in that size range will lead to a drop in the growth rate in the fish that feed in that size range. We can see the slow-down in growth by comparing the growth rates in the original model and the new model using `plot()` and `addPlot()`.
 
 ```{r}
-growth_rates_plot <- plot(getEGrowth(params))
-growth_rates_plot <- addPlot(growth_rates_plot, getEGrowth(params_starved))
+growth_rates_plot <- plot2(getEGrowth(params), getEGrowth(params_starved),
+                           name1 = "Original", name2 = "Less prey")
 growth_rates_plot
 ```
 

--- a/understand/single-species-spectra.qmd
+++ b/understand/single-species-spectra.qmd
@@ -211,7 +211,7 @@ p_biomass_cdf
 
 Mizer likes to work with arrays instead of data frames. Our variables `n`, `biomass`, `cumulative_biomass` and `cdf` are all arrays. I hope you noticed the magic how R can do calculations with all entries of an array in one go.
 
-ggplot2 on the other hand likes to work with data frames instead of arrays. The function `melt()` allows us to convert the mizer arrays into data frames suitable for `ggplot()`. You will see this discussed again later.
+ggplot2 on the other hand likes to work with data frames instead of arrays. The function `melt()` allows us to convert the mizer arrays into data frames suitable for `ggplot()`. Most mizer arrays that are returned by mizer functions have a `plot()` method, so you don't need to use `melt()` for those. But for derived arrays like `cdf` that are not direct mizer outputs, you still need `melt()` if you want to use `ggplot()`.
 :::
 
 This plot shows us for example that 50% of the individuals are smaller than 12.5g and only a very small percentage is larger than 75g.
@@ -322,7 +322,7 @@ We have seen that for juvenile fish the growth rate and the death rate are both 
 
 I won't do the maths here with you (and you probably don't want me to anyway), but we can see that the result makes sense. It tells us that the number density drops off faster with size if the mortality rate coefficient $\mu_0$ is higher or if the growth rate coefficient $g_0$ is smaller, which is what we would expect.
 
-We can also check this claim numerically. Let's look at the spectrum of individuals up to 10 grams. By now we know how to do this. We first convert the number density matrix `n` into a dataframe and then filter out all observations that do not have $w\leq 10$. The resulting data frame we pass to `ggplot()` and ask it to plot a line on log-log axes.
+We can also check this claim numerically. Let's look at the spectrum of individuals in log-log axes.
 
 ```{r}
 plot(n, log_x = TRUE, log_y = TRUE)


### PR DESCRIPTION
## Summary

Continues the work from commit 049acf7 which replaced `ggplot()` with `plot()` and `addPlot()` in `single-species-spectra.qmd`.

- **`predation-growth-and-mortality.qmd`**: Replace the `melt()`/`rbind()`/`ggplot()` growth rate comparison with `plot(getEGrowth(params))` + `addPlot()`, and remove a broken link to the now-deleted "Two curves in one plot" section
- **`single-species-spectra.qmd`**: Fix text at line 325 that still described the old `melt()`/`ggplot()` workflow even though the code had already been updated; clarify the note about `melt()` to explain that it is still needed for derived arrays (like `cdf`) that are not direct mizer outputs with a `plot()` method

The remaining `ggplot()` uses in other tutorials (pred_kernel plots, age-based growth curves, reproduction rate curves, and complex multi-panel time series plots) cannot be replaced because they either use custom data frames, arrays without a `plot()` method, or require custom facets/aesthetics not supported by the new plot methods.

## Test plan

- [ ] Verify `plot(getEGrowth(params))` and `addPlot()` render correctly in the predation-growth-and-mortality tutorial
- [ ] Check that text in single-species-spectra.qmd is now consistent with the code

🤖 Generated with [Claude Code](https://claude.com/claude-code)