### PR TITLE
Update species parameter docs for mizer 3.1 maximum-size changes

### DIFF
--- a/build/collect-parameters.qmd
+++ b/build/collect-parameters.qmd
@@ -115,9 +115,9 @@ If you don't like defaults you can change them all. You can find the complete li
 
 ### Asymptotic size
 
-The asymptotic size `w_max` is the size (in grams) at which all individuals of the species invest 100% of their energy income into reproduction and hence all growth stops. Due to variation between individuals, some individuals may stop growing earlier. So the `w_max` parameter in mizer is not the asymptotic size of an average individual but the maximum asymptotic size.
+The required size parameter in mizer is `w_inf`, the von Bertalanffy asymptotic size (in grams). This is the size that an average individual of the species would approach if it kept growing according to its von Bertalanffy growth curve. Mizer uses `w_inf` to set sensible defaults for several other size parameters, including the maturity size `w_mat`, the size `w_repro_max` at which a mature individual invests all its energy into reproduction, and the computational upper boundary of the size grid `w_max` (which defaults to `1.5 * w_inf`). Note that `w_inf` is not a hard limit on size: because individuals vary and because of diffusion in the growth process, some individuals will grow larger than `w_inf`.
 
-The best way to estimate this parameter is probably to look at what the largest fish is that has been caught in your study area. You may of course be fishing so hard that none of the fish grow to their asymptotic size and then the size of the largest caught fish would be an underestimate of the asymptotic size. But our estimate does not have to be perfect.
+A practical way to estimate `w_inf` is to look at the largest fish that has been caught in your study area. This will tend to slightly overestimate the asymptotic size of an average individual, and if you are fishing very hard it could instead be an underestimate, but our estimate does not have to be perfect.
 
 We have a data frame with observations of sizes of caught fish and can look through it for the largest sized fish of each species. 
 
@@ -176,13 +176,13 @@ length_weight
 
 Note that fishbase is continuously updated and the values you get for the length-weight conversion coefficients will change over time. The values above are already different from the ones in November 2022 when this course was first written.
 
-We can now add all this information to our species parameter data frame and use it to calculate the column we actually need, namely `w_max`.
+We can now add all this information to our species parameter data frame and use it to calculate the column we actually need, namely `w_inf`.
 
 ```{r}
 sp <- sp |>
     left_join(length_weight, by = c("latin_name" = "Species")) |>
     left_join(max_size) |>
-    mutate(w_max = a * l_max ^ b)
+    mutate(w_inf = a * l_max ^ b)
 sp
 ```
 
@@ -194,7 +194,7 @@ Now it is time again to add comments to remind us of the origin of our parameter
 comment(sp$a) <- "Taken from the `a` column in the 'estimates' table on FishBase on 07/12/2023."
 comment(sp$a) <- "Taken from the `b` column in the 'estimates' table on FishBase on 07/12/2023."
 comment(sp$l_max) <- "See https://mizer.course.sizespectrum.org/build/collect-parameters.html#asymptotic-size "
-comment(sp$w_max) <- "Calculated from `l_max` using weight-length parameters `a` and `b`."
+comment(sp$w_inf) <- "Calculated from `l_max` using weight-length parameters `a` and `b`."
 ```
 
 ### Growth parameters
@@ -323,7 +323,7 @@ There are many other parameters that are used to describe species properties, bu
 
 3.  The species **metabolic rate** is set from the metabolic rate constant `ks` and its body size scaling exponent `p`. If no value is provided, the coefficient `ks` is set so that at maturation size metabolic expenditure requires a critical feeding level of `fc = 0.2`. Maintenance expenditure can also include activity related energetic costs, using species activity coefficient `k` which scales linearly with body size (exponent of 1). By default this value is set to 0.
 
-4.  The **external mortality rate** (also called background or baseline mortality) is by default set to a size-independent constant `z0`. If no values are provided mizer assumes that species with small maximum body sizes have much higher baseline mortality rate. For example, a species with `w_max` = 35 g will have `z0` = 0.18, a species with `w_max` = 150g will have `z0` = 0.11 and a species with `w_max` = 14kg will have `z0` = 0.025.
+4.  The **external mortality rate** (also called background or baseline mortality) is by default set to a size-independent constant `z0`. If no values are provided mizer assumes that species with small asymptotic body sizes have much higher baseline mortality rate. For example, a species with `w_inf` = 35 g will have `z0` = 0.18, a species with `w_inf` = 150g will have `z0` = 0.11 and a species with `w_inf` = 14kg will have `z0` = 0.025.
 
 5.  We already discussed the parameters involved in setting the [investment into reproduction](..understand/single-species-spectra.hqmd#investment-into-reproduction) previously. The reproduction investment exponent `m` determines the scaling of the investment into reproduction for mature individuals. By default `m` = 1 which means that after maturation the rate at which individual fish invests energy into reproduction scales linearly with size (if you want more information, you can find it [here](https://sizespectrum.org/mizer/reference/setReproduction.html#investment-into-reproduction)). This default can be changed to another value if different scaling is preferred (e.g. in case you might want to explore [hyper-allometric reproduction investment options](https://www.pnas.org/doi/abs/10.1073/pnas.2100695118)). The steepness of population level energy allocation to reproduction is determined by `w_mat25`, the size at which 25% of individuals are mature.
 
@@ -389,7 +389,7 @@ The `catchability` column specifies how vulnerable the species are to commercial
 
 1\) The species parameters are specified in a data frame with one row for each species and one column for each species parameter.
 
-2\) Only a `species` name and the maximum size `w_max` of each species is strictly required. But for a realistic model you should try to also provide estimates of the maturity size `w_mat`, the maturity age `age_mat`, the preferred predator prey mass ratio `beta` and the observed biomasses `biomass_observed`.
+2\) Only a `species` name and the asymptotic size `w_inf` of each species is strictly required. But for a realistic model you should try to also provide estimates of the maturity size `w_mat`, the maturity age `age_mat`, the preferred predator prey mass ratio `beta` and the observed biomasses `biomass_observed`.
 
 3\) We briefly explained how mizer chooses defaults for many other parameters, often using allometric scaling assumptions.
 

--- a/understand/single-species-spectra.qmd
+++ b/understand/single-species-spectra.qmd
@@ -376,7 +376,7 @@ How was this maturity curve specified? You can find the details in the [mizer do
 
 -   the maturity size `w_mat` at which 50% of the individuals are mature.
 -   the size `w_mat25` at which 25% of the individuals are mature.
--   the asymptotic size `w_max` at which an organism invests 100% of its income into reproduction and thus growth is zero.
+-   the size `w_repro_max` at which a typical mature individual invests 100% of its income into reproduction. (This is not a hard upper size limit: not all individuals are mature at `w_repro_max`, and diffusion in the growth process allows some to grow beyond it.)
 -   an exponent `m` that determines how the proportion that an individual invests into reproduction scales with its size.
 
 Such species parameters are contained in a data frame inside the `params` object that we can access with the `species_params()` function.
@@ -389,7 +389,7 @@ species_params(params)
 As you can see, there are a lot of other species parameters, some of which we will talk about later. For now let's just select the 4 parameters we are interested in.
 
 ```{r}
-select(species_params(params), w_mat, w_mat25, w_max, m)
+select(species_params(params), w_mat, w_mat25, w_repro_max, m)
 ```
 
 And with this knowledge of parameters we can improve the plot for clarity and add a vertical line at 25% and 50% maturation weight
@@ -412,7 +412,7 @@ In this copy we now change the species parameters
 ```{r}
 given_species_params(params_changed_maturity)$w_mat <- 40
 given_species_params(params_changed_maturity)$w_mat25 <- 30
-select(species_params(params_changed_maturity), w_mat, w_mat25, w_max, m)
+select(species_params(params_changed_maturity), w_mat, w_mat25, w_repro_max, m)
 ```
 
 Now the maturity curve has changed, which we can verify by plotting it


### PR DESCRIPTION
Updates the course `.qmd` materials to match the maximum-size parameter changes in mizer 3.1 (sizespectrum/mizer#410, resolving sizespectrum/mizer#325).

In mizer 3.1:
- **`w_inf`** (von Bertalanffy asymptotic size) is the first-class, required maximum-size parameter.
- **`w_max`** is purely a computational boundary (defaults to `1.5 * w_inf`) and no longer influences any model parameter (including the external mortality default `z0`, which is now computed from `w_inf`).
- **`w_repro_max`** is the size at which a typical mature individual invests all its energy into reproduction — not a hard ceiling on size.

## Changes

- **`build/collect-parameters.qmd`** — the "Asymptotic size" section now estimates and stores `w_inf` (instead of `w_max`), with a corrected definition explaining the three size parameters. The external-mortality example refers to `w_inf` (the `z0` values are unchanged because `z0` is again computed from the asymptotic size).
- **`understand/single-species-spectra.qmd`** — the reproduction-investment size is `w_repro_max` (not `w_max`), with a note that it is not a hard upper size limit, and the `select()` chunks updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)